### PR TITLE
Fix silent output bug

### DIFF
--- a/src/HardwareBase.h
+++ b/src/HardwareBase.h
@@ -31,7 +31,6 @@ public:
 
 protected:
 private:
-    bool _value;
     int _address;
 #ifdef ESP_PLATFORM
     int _channel;

--- a/src/Musician.cpp
+++ b/src/Musician.cpp
@@ -1,10 +1,11 @@
 #include "Musician.h"
 
 #ifdef ESP_PLATFORM
-Musician::Musician(int address, int channel) : _hardwareBase(address, channel)
+Musician::Musician(int address, int channel) : _hardwareBase(address, channel),
 #else
-Musician::Musician(int address) : _hardwareBase(address)
+Musician::Musician(int address) : _hardwareBase(address),
 #endif
+_melody(nullptr), _breathDuration(0), TimeBase()
 {
 	setLoudnessLimit(DEFAULT_MINIMUM_LOUDNESS, DEFAULT_MAXIMUM_LOUDNESS);
 }

--- a/src/Musician.h
+++ b/src/Musician.h
@@ -37,10 +37,6 @@ private:
 	Melody *_melody;
 	void noTone();
 
-	bool _playing;
-	bool _pausing;
-	unsigned long _startTime;
-	unsigned long _duree;
 	unsigned long _breathDuration;
 	int _min, _max;
 };

--- a/src/TimeBase.cpp
+++ b/src/TimeBase.cpp
@@ -1,6 +1,6 @@
 #include "TimeBase.h"
 
-TimeBase::TimeBase()
+TimeBase::TimeBase() : _playing(false), _pausing(false), _startTime(0), _duree(0)
 {
 	stop();
 }


### PR DESCRIPTION
On some occasions I've found that Musician stops playing any notes.

As `_breathDuration` in `Musician` is not initialised at construction time, if the breath duration is not subsequently set with `setBreath()`, the duration may be some arbitrarily large number (whatever is in the uninitialised memory). In `TimeBase::refresh()`, we then subtract that large duration from every note, resulting in the note stopping (`noSound()`) almost as soon as it has started playing.

This PR ensures that `_breathDuration` is initialised to zero and, per best practice, also initialises all other variables in `Musician` and `TimeBase` to sensible defaults (in the case of `TimeBase` by calling its constructor in the initialiser list of `Musician`).

For tidiness, the unused member `_value` in `HardwareBase` is also removed, as are the unused members in `Musician` (these aren't needed, as the identically named private members in `TimeBase` are the ones that are actually used).